### PR TITLE
Setup CI for building and releasing package

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/python-build-publish.yaml
+++ b/.github/workflows/python-build-publish.yaml
@@ -1,0 +1,70 @@
+name: Build and upload to PyPI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # v2.17.0
+
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/fishhook/
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: "Publish distribution 📦 to PyPI"
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+        with:
+          skip-existing: true
+          verbose: true
+          print-hash: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "fishhook"
+version = "0.3.1"
+description = "Allows for runtime hooking of static class functions"
+authors = [
+    { name = "chilaxan", email = "chilaxan@gmail.com" },
+]
+license = { text = "MIT" }
+readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "capstone",
+    "keystone-engine",
+]
+
+[project.urls]
+repository = "https://github.com/chilaxan/fishhook"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["fishhook"]

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,7 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
 setuptools.setup(
-    name="fishhook",
-    version="0.3.1",
-    author="chilaxan",
-    author_email="chilaxan@gmail.com",
-    description="Allows for runtime hooking of static class functions",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/chilaxan/fishhook",
-    packages=['fishhook'],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+    ext_modules=[
+        setuptools.Extension("fishhook._asm", sources=["fishhook/_asmmodule.c"])
     ],
-    python_requires='>=3.8',
-    ext_modules=[setuptools.Extension('fishhook._asm', sources=['fishhook/_asmmodule.c'])],
-    install_requires=['capstone', 'keystone-engine']
 )


### PR DESCRIPTION
- Move all static package metadata to `pyproject.toml` in accordance with PEPs 621 and 517
- Create a workflow to build the package on PR and merge, and to publish to PyPI when a release is created
- Create a Dependabot config to keep the workflow dependencies up-to-date

You will need to follow the steps in https://docs.pypi.org/trusted-publishers/adding-a-publisher/ before the workflow will have access to publish your package.