### PR TITLE
Enable building wheels for both pre-release and free threaded versions of Python

### DIFF
--- a/.github/workflows/python-build-publish.yaml
+++ b/.github/workflows/python-build-publish.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
+        env:
+          CIBW_ENABLE: cpython-prerelease cpython-freethreading
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
This can also be [configured via pyproject.toml](https://cibuildwheel.pypa.io/en/stable/options/#enable) config, let me know if you would prefer that and I can switch.